### PR TITLE
Run benchmarks

### DIFF
--- a/jolt-core/Cargo.toml
+++ b/jolt-core/Cargo.toml
@@ -85,6 +85,10 @@ common = { path = "../common" }
 name = "iai"
 harness = false
 
+[[bench]]
+name = "sumcheck"
+harness = false
+
 [lib]
 name = "jolt_core"
 path = "src/lib.rs"

--- a/jolt-core/benches/sumcheck.rs
+++ b/jolt-core/benches/sumcheck.rs
@@ -1,0 +1,58 @@
+use ark_bn254::Fr;
+use ark_std::rand::prelude::ThreadRng;
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
+use jolt_core::poly::dense_mlpoly::DensePolynomial;
+use jolt_core::subprotocols::sumcheck::SumcheckInstanceProof;
+use jolt_core::utils::transcript::ProofTranscript;
+use rayon::iter::IndexedParallelIterator;
+use rayon::iter::ParallelIterator;
+use rayon::prelude::IntoParallelRefIterator;
+
+fn bench_sumcheck_internal(c: &mut Criterion, num_prods: usize) {
+    let mut group = c.benchmark_group(format!("sumcheck<prod={}>", num_prods));
+    group.sample_size(10);
+
+    let mut rng = ThreadRng::default();
+    for nv in 20..24 {
+        if num_prods == 2 {
+            group.bench_function(BenchmarkId::new("prove_quadratic", nv), |b| {
+                b.iter_batched(
+                    || {
+                        let poly_a = DensePolynomial::<Fr>::random(nv, &mut rng);
+                        let poly_b = DensePolynomial::<Fr>::random(nv, &mut rng);
+                        let transcript = ProofTranscript::new(b"bench_sumcheck");
+
+                        let expected_sum = poly_a
+                            .Z
+                            .par_iter()
+                            .zip(poly_b.Z.par_iter())
+                            .map(|(a, b)| a * b)
+                            .sum::<Fr>();
+
+                        (poly_a, poly_b, expected_sum, transcript)
+                    },
+                    |(mut poly_a, mut poly_b, expected_sum, mut transcript)| {
+                        SumcheckInstanceProof::<Fr>::prove_quadratic(
+                            &expected_sum,
+                            nv,
+                            &mut poly_a,
+                            &mut poly_b,
+                            &mut transcript,
+                        );
+                    },
+                    BatchSize::SmallInput,
+                );
+            });
+        } else if num_prods == 3 {
+        }
+    }
+}
+
+fn bench_sumcheck(c: &mut Criterion) {
+    // bench sumcheck prover for product of two multilinear polynomials
+    bench_sumcheck_internal(c, 2);
+
+    // TODO: bench sumcheck for product of three multilinear polynomials
+}
+criterion_group!(benches, bench_sumcheck);
+criterion_main!(benches);

--- a/jolt-core/src/poly/dense_mlpoly.rs
+++ b/jolt-core/src/poly/dense_mlpoly.rs
@@ -129,6 +129,7 @@ impl<F: JoltField> DensePolynomial<F> {
             .zip(right.par_iter())
             .filter(|(&mut a, &b)| a != b)
             .for_each(|(a, b)| {
+                // a(i,r) = (1-r)*a[i,0] + r*a[i,1] = a[i,0] + r*(a[i,1]-a[i,0])
                 *a += *r * (*b - *a);
             });
 


### PR DESCRIPTION
## Sumcheck 

| Benchmark                               | Time Range (ms)   [^1]           |
|-------------------------------------|------------------------------|
| sumcheck<prod=2>/prove_quadratic/20 | 21.97 - 22.93 ms             |
| sumcheck<prod=2>/prove_quadratic/21 | 40.74 - 43.34 ms             |
| sumcheck<prod=2>/prove_quadratic/22 | 79.56 - 86.25 ms             |
| sumcheck<prod=2>/prove_quadratic/23 | 154.72 - 159.15 ms           |

As a comparison, ceno sumcheck over Goldilocks / GoldilocksExt2 runs in 6.5ms for nv = 20. https://hackmd.io/@kunxian-xia/BkiQb1hL0


[^1]: Apple M1 Pro 10 cores, 16GB RAM.